### PR TITLE
Allow middleware to stop request handling

### DIFF
--- a/wraphh.go
+++ b/wraphh.go
@@ -41,5 +41,6 @@ func WrapHH(hh func(h http.Handler) http.Handler) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		hh(&nextRequestHandler{c}).ServeHTTP(c.Writer, c.Request)
+		c.Abort()
 	}
 }


### PR DESCRIPTION
When a middleware like [rs/cors](https://github.com/rs/cors/blob/fcebdb403f4d4585c705318c0e4d6d05a761a4ab/cors.go#L228-L231) does not want pass control to the next in the chain, we need to explicitly instruct gin to stop the chain by calling Abort.